### PR TITLE
Fix multiple encoder events being sent

### DIFF
--- a/app/boards/shields/draculad/draculad.dtsi
+++ b/app/boards/shields/draculad/draculad.dtsi
@@ -47,14 +47,14 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,1)         RC(3,8) RC(2,5) RC(2,6) 
             compatible = "alps,ec11";
             label = "LEFT_ENCODER";
             a-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-            b-gpios = <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            b-gpios = <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
             resolution = <4>;
         };
 
     right_encoder: encoder_right {
             compatible = "alps,ec11";
             label = "RIGHT_ENCODER";
-            a-gpios = <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            a-gpios = <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
             b-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
             resolution = <4>;
     };

--- a/app/boards/shields/draculad/draculad.dtsi
+++ b/app/boards/shields/draculad/draculad.dtsi
@@ -54,8 +54,8 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,1)         RC(3,8) RC(2,5) RC(2,6) 
     right_encoder: encoder_right {
             compatible = "alps,ec11";
             label = "RIGHT_ENCODER";
-            a-gpios = <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-            b-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            a-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            b-gpios = <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
             resolution = <4>;
     };
 


### PR DESCRIPTION
This change fixed the issue that left and right encoder keys were sent at the same time.

A keymap config like this:
sensor-bindings = <&inc_dec_kp A B &inc_dec_kp C D>;

Was sending "ac" or "bd". After the change only one keystroke is registered as intended.

Also the gpio pins for the right side are the wrong way around. To make the right one work with nice!nano, have a look at the changes here: https://github.com/zmkfirmware/zmk/pull/728#issuecomment-1104686605

Apparently that solution won't make it to the official zmk main at the moment, but it works for me :)